### PR TITLE
Bump version skie 0.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.0"
-skie = "0.4.19"
+skie = "0.5.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }


### PR DESCRIPTION
Run successfully

https://github.com/touchlab/SKIE/releases/tag/0.5.0